### PR TITLE
Don’t pin the versions since we’re a template repository

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "rangeStrategy": "replace"
 }


### PR DESCRIPTION
Required for #5 and the related Composer linter errors.