### PR TITLE
Allow deploys to be skipped

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ deploy:
     skip_cleanup: true
     on:
       branch: master
+      condition: -z $SKIP_DEPLOY
 
   # Deploy to staging.
   - provider: script
@@ -31,6 +32,7 @@ deploy:
     skip_cleanup: true
     on:
       branch: develop
+      condition: -z $SKIP_DEPLOY
 
 # Travis must run on brances that need to be deployed.
 branches:


### PR DESCRIPTION
Useful when testing the deploy pipeline locally, for example. Also required for our template repository until we get a demo site configured on VIP Go.