### PR TITLE
Add default ports for mySQL in docker-compose.yml.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
 
   db:
     image: mysql:5.7
+    ports:
+      - "3306:3306"
     volumes:
       - db_data:/var/lib/mysql
     restart: always


### PR DESCRIPTION
Allows for connecting to the database from an external tool.