### PR TITLE
Add support for sub-directory multisite setup

### DIFF
--- a/local/docker/nginx/config/conf.d/devgo.conf
+++ b/local/docker/nginx/config/conf.d/devgo.conf
@@ -17,4 +17,10 @@ server {
 		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 		include fastcgi_params;
 	}
+
+	# Add support for subdirectory structure in WordPress Multisite
+	if (!-e $request_filename) {
+		rewrite ^/[^/]+/(wp-.*) /$1 last;
+		rewrite ^/[^/]+/(.*\.php)$ /$1 last;
+	}
 }


### PR DESCRIPTION
When setting up a sub-directory multisite, the current settings is causing a redirect-loop when viewing the subsite backend. This PR fixes that issue. 

Tested this on the GIC multisite local environment and it works.