### PR TITLE
Add local definition for VIP_GO_APP_ENVIRONMENT.

### DIFF
--- a/local/public/wp-config.php
+++ b/local/public/wp-config.php
@@ -20,6 +20,9 @@ define( 'DISALLOW_FILE_MODS', true );
 define( 'DISALLOW_FILE_EDIT', true );
 define( 'AUTOMATIC_UPDATER_DISABLED', true );
 
+// Define the local environment.
+define( 'VIP_GO_APP_ENVIRONMENT', 'local' );
+
 // Respond as if we were on HTTPS.
 if ( isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) && 'https' === $_SERVER['HTTP_X_FORWARDED_PROTO'] ) {
 	$_SERVER['HTTPS'] = 'on';


### PR DESCRIPTION
The VIP_GO_APP_ENVIRONMENT is used to distinguish between environment on the VIP Go platform, but it would be useful to have this environment defined locally in those (rare) instances where we want something to run locally and nowhere else.