### PR TITLE
Update mkcert Dockerfile

### DIFF
--- a/local/docker/mkcert/Dockerfile
+++ b/local/docker/mkcert/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.16-alpine
 RUN apk add --no-cache git
 
 RUN cd /go \
-	&& go get -u github.com/FiloSottile/mkcert \
-	&& cd src/github.com/FiloSottile/mkcert \
+	&& git clone https://github.com/FiloSottile/mkcert \
+	&& cd mkcert \
 	&& go build -ldflags "-X main.Version=$(git describe --tags)" -o /bin/mkcert
 
 WORKDIR /root/.local/share/mkcert


### PR DESCRIPTION
Updated `mkcert` to be fetched using `git clone` instead of `go get`.

An extract from the `v.1.4.2` [release page](https://github.com/FiloSottile/mkcert/releases/tag/v1.4.2):

> The Go import path of the module is now filippo.io/mkcert, which should only affect users installing the tool with go get, which was never a recommended installation method.
