### PR TITLE
fix: re-include individual plugin vendor folders

### DIFF
--- a/.distinclude
+++ b/.distinclude
@@ -23,7 +23,11 @@
 - node_modules/
 - tests/
 - test/
-- /plugins/vendor/
+- /plugins/vendor/automattic/vip-go-mu-plugins/
+- /plugins/vendor/bin/
+- /plugins/vendor/phpunit/
+- /plugins/vendor/phpstan/
+- /plugins/vendor/squizlabs/
 
 # Development config files
 - package.json


### PR DESCRIPTION
## Tasks

- [x] Re-include individual plugin vendor folders

## Describe the Approach

- The existing exclusion was removing `vendor` folder from all places, which is wrong. Some plugins have this folder and need them.